### PR TITLE
feat: add client types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Vite plugin to transform SVGs into React components. Uses [svgr](https://github.com/gregberge/svgr) under the hood.
 
+## Prerequisites:
+
+add `vite-plugin-svgr/client` to `compilerOptions.types` of your `tsconfig`
+
+```js
+"types": ["vite-plugin-svgr/client"]
+```
+
 ## Usage
 
 ```js
@@ -17,7 +25,7 @@ export default {
 Then SVG files can be imported as React components, just like [create-react-app](https://create-react-app.dev/docs/adding-images-fonts-and-files#adding-svgs) does:
 
 ```js
-import { ReactComponent as Logo } from './logo.svg';
+import { ReactComponent as Logo } from './logo.svg'
 ```
 
 ## License

--- a/client.d.ts
+++ b/client.d.ts
@@ -1,0 +1,10 @@
+declare module '*.svg' {
+    import * as React from 'react';
+  
+    export const ReactComponent: React.FunctionComponent<
+      React.SVGProps<SVGSVGElement> & { title?: string }
+    >;
+  
+    const src: string;
+    export default src;
+  }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "git+https://github.com/pd4d10/vite-plugin-svgr.git"
   },
   "files": [
-    "lib"
+    "lib",
+    "client.d.ts"
   ],
   "keywords": [
     "vite"


### PR DESCRIPTION
Hello @pd4d10,

As we discussed, I have exposed client types. Client types should be exposed under `vite-plugin-svgr/client.d.ts` and I have provided type definition for the svg.

Solving: 
https://github.com/pd4d10/vite-plugin-svgr/issues/3