### PR TITLE
Allow specifying svgr options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ import svgrPlugin from 'vite-plugin-svgr'
 
 export default {
   // ...
-  plugins: [svgrPlugin()],
+  plugins: [
+    svgrPlugin({
+      svgrOptions: {
+        icon: true,
+        // ...svgr options (https://react-svgr.com/docs/options/)
+      },
+    }),
+  ],
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "vite": "^2.6.13"
   },
   "peerDependencies": {
-    "vite": "^2.0.0"
+    "vite": "^2.6.0"
   },
   "dependencies": {
-    "@svgr/core": "^6.0.0-alpha.2"
+    "@svgr/core": "^6.0.0-alpha.3"
   }
 }


### PR DESCRIPTION
Closes #10 

This adds the ability to specify `svgrOptions` to the plugin, which are passed along to svgr.

I also copied and slightly modified the type definitions from https://github.com/gregberge/svgr/pull/555 and included them in the built files, so that consuming typescript projects have access to them.

I've tested this by running `npm run build`, then copying `lib` into the `node_modules` of my own typescript vite project, and the options were applied correctly and the typescript definitions worked as well.