### PR TITLE
change export to export default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ type Options = {
   esbuildOptions?: Parameters<typeof transformWithEsbuild>[2]
 }
 
-export deafult function svgrPlugin({
+export default function svgrPlugin({
   svgrOptions,
   esbuildOptions,
 }: Options = {}): Plugin {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ type Options = {
   esbuildOptions?: Parameters<typeof transformWithEsbuild>[2]
 }
 
-export = function svgrPlugin({
+export deafult function svgrPlugin({
   svgrOptions,
   esbuildOptions,
 }: Options = {}): Plugin {


### PR DESCRIPTION
I got this error.
```
import svgrPlugin
Module '"/Users/insik/Documents/workspace/rentbank-admin-web/node_modules/vite-plugin-svgr/lib/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flagts(1259)
index.d.ts(9, 1): This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
Module '"/Users/insik/Documents/workspace/rentbank-admin-web/node_modules/vite-plugin-svgr/lib/index"' can only be default-imported using the 'allowSyntheticDefaultImports' flagts(1259)
index.d.ts(9, 1): This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
```
I think this problem is export .