### PR TITLE
Pass filePath to SVGR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export = function svgrPlugin({
 
         const componentCode = await convert(svgCode, svgrOptions, {
           componentName: 'ReactComponent',
+          filePath: id,
         }).then((res) => {
           return res.replace(
             'export default ReactComponent',


### PR DESCRIPTION
Pass `filePath` to SVGR so that it can be picked up by SVGR plugins like SVGO.