### PR TITLE
feat: supports export default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,18 @@ If you are using TypeScript, there is also a declaration helper for better type 
 
 ```js
 svgr({
+  // Set it to `true` to export React component as default.
+  // Notice that it will overrides the default behavior of Vite.
+  exportAsDefault: false,
+
+  // svgr options: https://react-svgr.com/docs/options/
   svgrOptions: {
-    // svgr options: https://react-svgr.com/docs/options/
+    // ...
   },
+
+  // esbuild options, to transform jsx to js
   esbuildOptions: {
-    // esbuild options, to transform jsx to js
+    // ...
   },
 })
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,19 @@ import { transformWithEsbuild } from 'vite'
 import type { Plugin } from 'vite'
 
 export interface ViteSvgrOptions {
+  /**
+   * Export React component as default. Notice that it will overrides
+   * the default behavior of Vite, which exports the URL as default
+   *
+   * @default false
+   */
+  exportAsDefault?: boolean
   svgrOptions?: Config
   esbuildOptions?: Parameters<typeof transformWithEsbuild>[2]
 }
 
 export default function viteSvgr({
+  exportAsDefault,
   svgrOptions,
   esbuildOptions,
 }: ViteSvgrOptions = {}): Plugin {
@@ -22,7 +30,7 @@ export default function viteSvgr({
         const componentCode = await transform(svgCode, svgrOptions, {
           filePath: id,
           caller: {
-            previousExport: code,
+            previousExport: exportAsDefault ? null : code,
           },
         })
 


### PR DESCRIPTION
As we discussed in #2, Vite itself has export `string` as default for `*.svg`, so we choose the [CRA pattern]() instead of `export default` to avoid conflict.

In the meantime, some users have requested this feature (#2, #26, #30). Although it conflicts with Vite's default, it may be worthwhile to implement it as an option.

Due to the git conflicts of previous PRs, I submit a new PR to implement this feature. Hope you don't mind @AndyBan, @willstott101

Also cc @Jinjiang

Closes #2
Closes #30