### PR TITLE
feat: support latest React version (17 and above)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "vite": "^2.9.6"
   },
   "peerDependencies": {
-    "vite": "^2.6.0"
+    "vite": "^2.6.0",
+    "react": ">=17"
   },
   "dependencies": {
     "@svgr/core": "^6.2.1"


### PR DESCRIPTION
### What is the issue
svgr has a devDependencies for react set to version 17. It is not possible to use the package `vite-plugin-svgr` with the [last version of react](https://reactjs.org/blog/2022/03/29/react-v18.html), which is the version 18.
It throws the following error :
```
Could not resolve dependency:
peer react@"17.0.2" from vite-plugin-svgr-component@1.0.0
node_modules/vite-plugin-svgr-component
dev vite-plugin-svgr-component@"1.0.0" from the root project
```

### Proposed solution
This solution intend to specifically state the peerDependencies for react, and allow everyone to use this plugin with the latest version of React.
