### PR TITLE
feat: support path query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export default function viteSvgr({
     async transform(code, id) {
       if (filter(id)) {
         const { transform } = await import('@svgr/core')
-        const svgCode = await fs.promises.readFile(id, 'utf8')
+        const svgCode = await fs.promises.readFile(id.replace(/\?.*$/, ""), 'utf8')
 
         const componentCode = await transform(svgCode, svgrOptions, {
           filePath: id,


### PR DESCRIPTION
allow use query in .svg path

```ts
import Icon from "/path/to/svg/icon.svg?component"
```

in config

```ts
{
   plugins: [svgr({
      includes:[ "**/*.svg?component" ]
   })]
}
```


