### PR TITLE
feat: allow 7.x and 8.x versions of svgr packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.0.2",
-    "@svgr/core": "^7.0.0",
-    "@svgr/plugin-jsx": "^7.0.0"
+    "@svgr/core": "^7.0.0 || ^8.0.0",
+    "@svgr/plugin-jsx": "^7.0.0 || ^8.0.0"
   },
   "packageManager": "pnpm@8.4.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ dependencies:
     specifier: ^5.0.2
     version: 5.0.2
   '@svgr/core':
-    specifier: ^7.0.0
+    specifier: ^7.0.0 || ^8.0.0
     version: 7.0.0
   '@svgr/plugin-jsx':
-    specifier: ^7.0.0
+    specifier: ^7.0.0 || ^8.0.0
     version: 7.0.0
 
 devDependencies:


### PR DESCRIPTION
Hello there. I'm using this plugin in a repository which also uses the latest version of `@svgr/webpack`, and ideally I'd like to use the same `@svgr/core` and `@svgr/plugin-*` packages for both Vite and Webpack.

SVGR 8.0.0 was released a couple months ago and has very limited breaking changes. I think it should be safe to allow this plugin to be used with both v7 and v8 of `@svgr/core` and `@svgr/plugin-jsx` packages. What do you think?

https://github.com/gregberge/svgr/releases/tag/v8.0.0