### PR TITLE
fix: trim query from fileName passed to svgr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ export default function viteSvgr({
   exclude,
 }: ViteSvgrOptions = {}): Plugin {
   const filter = createFilter(include, exclude);
+  const postfixRE = /[?#].*$/s;
+
   return {
     name: "vite-plugin-svgr",
     async transform(code, id) {
@@ -33,13 +35,11 @@ export default function viteSvgr({
         const { transform } = await import("@svgr/core");
         const { default: jsx } = await import("@svgr/plugin-jsx");
 
-        const svgCode = await fs.promises.readFile(
-          id.replace(/\?.*$/, ""),
-          "utf8"
-        );
+        const filePath = id.replace(postfixRE, "");
+        const svgCode = await fs.promises.readFile(filePath, "utf8");
 
         const componentCode = await transform(svgCode, svgrOptions, {
-          filePath: id,
+          filePath,
           caller: {
             previousExport: exportAsDefault ? null : code,
             defaultPlugins: [jsx],


### PR DESCRIPTION
Fixes #80.

This PR removes any query string or URL-like hash from the import `id` before passing that value to SVGR as `state.filePath`.

This fixes usage of this plugin with query parameters (`import SvgComponent from './file.svg?something'`) and with some SVGR plugins such as `@svgr/plugin-svgo`).

### Analysis of the problem

This plugin is using the import `id` in 4 different steps:

1. To check it against the `include` and `exclude` options (using `@rollup/pluginutils`'s `createFilter` function).
2. To read the SVG file from disk (`fs.promises.readFile`).
3. As the `state.fileName` value for `@svgr/core`'s `transform` function.
4. As the `filename` value for Vite's `transformWithEsbuild` function.

An issue arises when the import id contains a query string, and this plugin is configured to accept this query string, for instance:

```js
// vite.config.js
svgr({ include: '**/*.svg?react' })

// SomeComponent.js
import './some/image.svg?react';
```

Each of the 4 steps listed above have different expectations here:

1. The `createFilter` function accepts patterns containing query strings, such as `**/*.svg?foo`. So here we should pass the `id` value as-is.
2. To read the SVG file from disk, we need the file path without any query string, since in Vite land such a query string represents metadata for Vite/Rollup and is not part of the actual path.
3. SVGR seems to expect the `state.fileName` value to not include a query string. It's a bit hard to say because there's no documentation, but looking at source code:
    - Here it extracts the file name without with Node's `path.parse(fileName).name`: https://github.com/gregberge/svgr/blob/82928f02e4a2ae1160e54884461f9edde4ad2293/packages/core/src/state.ts#L18-L27
    - It will pass the `state.fileName` as-is to `cosmiconfig` as a base path to search from: https://github.com/gregberge/svgr/blob/82928f02e4a2ae1160e54884461f9edde4ad2293/packages/core/src/config.ts#L83
    - It will also pass the `state` object to plugins, but I haven't checked what plugins do.
4. The `transformWithEsbuild` function does expect the `filename` parameter to contain the import id's query string, if any:
    - See https://github.com/vitejs/vite/blob/d4f13bd81468961c8c926438e815ab6b1c82735e/packages/vite/src/node/plugins/esbuild.ts#L170-L171
