### PR TITLE
docs: remove obsolete statement about default included files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ svgr({
     // ...
   },
 
-  // A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should include. By default all svg files will be included.
+  // A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should include.
   include: "**/*.svg?react",
 
   //  A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should ignore. By default no files are ignored.


### PR DESCRIPTION
Just a small detail in the documentation that I got tripped up on today, the current default is to use the `**/*.svg?react` pattern, not to include all svg files.