### PR TITLE
added codemods to migrate named export to default in v4

### DIFF
--- a/codemods/package.json
+++ b/codemods/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "codemods",
+  "version": "0.0.0",
+  "type": "commonjs",
+  "exports": {
+    "./package.json": "./package.json"
+  }
+}

--- a/codemods/readme.md
+++ b/codemods/readme.md
@@ -1,0 +1,29 @@
+# Codemod
+
+## V4
+convert named export to default 
+
+If you want to run it against `.js` or `.jsx` files, please use the command below:
+
+```
+npx jscodeshift@latest ./path/to/src/ \
+  --extensions=js,jsx \
+  --transform=./node_modules/vite-plugin-svgr/codemods/src/v4/default-export/default-export.js
+```
+
+If you want to run it against `.ts` or `.tsx` files, please use the command below:
+
+```
+npx jscodeshift@latest ./path/to/src/ \
+  --extensions=ts,tsx \
+  --parser=tsx \
+  --transform=./node_modules/vite-plugin-svgr/codemods/src/v4/default-export/default-export.js
+```
+
+**Note:** Applying the codemod might break your code formatting, so please don't forget to run `prettier` and/or `eslint` after you've applied the codemod!
+
+Above codemod will convert as imports as bellow
+```diff
+- import { ReactComponent as NoticeModeIconActive2 } from 'assets/icon.svg';
++ import NoticeModeIconActive2 from 'assets/icon.svg?react';
+```

--- a/codemods/src/v4/default-export/default-export.js
+++ b/codemods/src/v4/default-export/default-export.js
@@ -1,0 +1,32 @@
+module.exports = function (file, api) {
+    const jscodeshift = api.jscodeshift;
+    const root = jscodeshift(file.source);
+
+    root.find(jscodeshift.ImportDeclaration).forEach((path) => {
+        const importPath = path.node.source.value;
+
+        if (importPath.endsWith('.svg')) {
+
+            const hasDefaultSpecifier = path.node.specifiers.some(specifier =>
+                jscodeshift.ImportDefaultSpecifier.check(specifier)
+            );
+
+            // Skip transformation if there is a default import specifier
+            if (!hasDefaultSpecifier) {
+                const updatedImportPath = `${importPath}?react`;
+
+                path.node.specifiers.forEach(specifier => {
+                    if (jscodeshift.ImportSpecifier.check(specifier)) {
+                        // Convert named import to default import
+                        const newSpecifier = jscodeshift.importDefaultSpecifier(jscodeshift.identifier(specifier.local.name));
+                        specifier.type = 'ImportDefaultSpecifier';
+                        specifier.local = newSpecifier.local;
+                    }
+                });
+
+                path.node.source = jscodeshift.literal(updatedImportPath);
+            }
+        }
+    });
+    return root.toSource();
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "repository": "pd4d10/vite-plugin-svgr",
   "files": [
     "dist",
-    "client.d.ts"
+    "client.d.ts",
+    "codemods"
   ],
   "keywords": [
     "vite",


### PR DESCRIPTION
This PR adds codemod to make it easy to migrate to v4

It converts named export to default export 
plus adds `?react` postfix  to import path

```diff
- import { ReactComponent as NoticeModeIconActive2 } from 'assets/icon.svg';
+ import NoticeModeIconActive2 from 'assets/icon.svg?react';
```