### PR TITLE
Add note about TypeScript usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ svgr({
 });
 ```
 
+If you want to use TypeScript, i.e., generate `.tsx` components, you need to set `typescript: true` in `svgrOptions` and `loader: 'tsx'` in `esbuildOptions`:
+
+```ts
+svgr({
+  svgrOptions: {
+    typescript: true,
+  },
+  esbuildOptions: {
+    loader: 'tsx',
+  },
+})
+```
+
+(Setting `typescript: true` will add `import type { SVGProps } from "react";` to the generated component, which esbuild won't recognize as valid syntax without setting `loader: 'tsx'`.)
+
 ## License
 
 MIT


### PR DESCRIPTION
It took me a while to figure out why I was getting this error when I set `typescript: true` in `svgrOptions`:

```
ERROR: Expected "from" but found "{"
1  |  import * as React from "react";
2  |  import type { SVGProps } from "react";
```

The answer was that I had to set `loader: 'tsx'` in `esbuildOptions`, since otherwise esbuild wouldn't recognize the `import type` syntax as valid. I figured maybe adding this to the docs could help someone someday.
