### PR TITLE
feat: support `rolldown-vite` via feature detection of `vite.transformWithOxc`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ import type { Config } from "@svgr/core";
 import fs from "fs";
 import type { Plugin } from "vite";
 import { transformWithEsbuild } from "vite";
+import * as viteModule from "vite";
+
+// @ts-ignore - check if transformWithOxc is available, i.e. rolldown-vite is installed and aliased
+let useOxc = viteModule.transformWithOxc != null;
+// @ts-ignore - assign transformer function
+let transformWith: typeof transformWithEsbuild = useOxc ? viteModule.transformWithOxc : transformWithEsbuild;
 
 export interface VitePluginSvgrOptions {
   svgrOptions?: Config;
@@ -38,7 +44,11 @@ export default function vitePluginSvgr({
           },
         });
 
-        const res = await transformWithEsbuild(componentCode, id, {
+        const res = await transformWith(componentCode, id, useOxc ? {
+          // @ts-ignore - "lang" is required for transformWithOxc
+          lang: "jsx",
+          ...esbuildOptions,
+        } : {
           loader: "jsx",
           ...esbuildOptions,
         });


### PR DESCRIPTION
Support `rolldown-vite` by feature detection of `transformWithOxc`.

Tested with:
- `"vite": "^6.3.2"`
- and `"vite": "npm:rolldown-vite@latest"`

build and dev server work 👌 

A little bit unsure if I'm causing any issues by using `import *` or not but happy for any suggestions for improvements.