### PR TITLE
fix: correct OxcTransformOptions type to expose jsx options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,10 @@ import fs from "node:fs";
 import type {
   EsbuildTransformOptions,
   Plugin,
-  TransformOptions as OxcTransformOptions,
+  transformWithOxc,
 } from "vite";
+
+type OxcTransformOptions = NonNullable<Parameters<typeof transformWithOxc>[2]>;
 
 export interface VitePluginSvgrOptions {
   svgrOptions?: Config;


### PR DESCRIPTION
## Problem

`OxcTransformOptions` was imported as `TransformOptions` from `"vite"`, but that type is vite's dev server **request** transform options (`{ ssr?: boolean }`), completely unrelated to the oxc transformer. This meant users couldn't pass oxc-specific options like `jsx.runtime` without TypeScript errors.

## Fix

Derive the type directly from `transformWithOxc`'s own parameter signature:

```ts
type OxcTransformOptions = NonNullable<Parameters<typeof transformWithOxc>[2]>;
```

This keeps the type automatically in sync with whatever vite/rolldown exposes, and correctly surfaces fields like `jsx.runtime`:

```ts
svgr({
  oxcOptions: {
    jsx: {
      runtime: 'classic',
    },
  },
})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)