### PR TITLE
feat: add jsxRuntime option

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "vite": ">=3.0.0"
   },
   "dependencies": {
-    "@rollup/pluginutils": "^5.3.0",
     "@svgr/core": "^8.1.0",
     "@svgr/plugin-jsx": "^8.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@rollup/pluginutils':
-        specifier: ^5.3.0
-        version: 5.3.0(rollup@4.60.0)
       '@svgr/core':
         specifier: ^8.1.0
         version: 8.1.0(typescript@6.0.2)
@@ -908,15 +905,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.12':
     resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
-  '@rollup/pluginutils@5.3.0':
-    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/rollup-android-arm-eabi@4.60.0':
     resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
     cpu: [arm]
@@ -1430,9 +1418,6 @@ packages:
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
-
-  estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2723,14 +2708,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.12': {}
 
-  '@rollup/pluginutils@5.3.0(rollup@4.60.0)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.4
-    optionalDependencies:
-      rollup: 4.60.0
-
   '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
 
@@ -3217,8 +3194,6 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@1.0.5: {}
-
-  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ interface VitePluginSvgrOptions {
   oxcOptions?: OxcTransformOptions;
   exclude?: FilterPattern;
   include?: FilterPattern;
+  jsxRuntime?: "classic" | "automatic";
 }
 
 export default function vitePluginSvgr({
@@ -23,6 +24,7 @@ export default function vitePluginSvgr({
   oxcOptions,
   include = "**/*.svg?react",
   exclude,
+  jsxRuntime,
 }: VitePluginSvgrOptions = {}): Plugin {
   const filter = createFilter(include, exclude);
   const postfixRE = /[?#].*$/s;
@@ -42,19 +44,28 @@ export default function vitePluginSvgr({
       /* c8 ignore next 2 */
       const { transform: svgrTransform } = await import("@svgr/core");
       const { default: jsx } = await import("@svgr/plugin-jsx");
-      const componentCode = await svgrTransform(svgCode, svgrOptions, {
-        filePath,
-        caller: {
-          defaultPlugins: [jsx],
+      const componentCode = await svgrTransform(
+        svgCode,
+        {
+          jsxRuntime,
+          ...svgrOptions,
         },
-      });
-      const meta = (this as { meta?: { rolldownVersion?: string } } | undefined)?.meta;
+        {
+          filePath,
+          caller: {
+            defaultPlugins: [jsx],
+          },
+        },
+      );
+      const meta = (this as { meta?: { rolldownVersion?: string } } | undefined)
+        ?.meta;
 
       if (meta?.rolldownVersion != null) {
         /* c8 ignore next */
         const { transformWithOxc } = await import("vite");
         const res = await transformWithOxc(componentCode, id, {
           lang: "jsx",
+          jsx: { runtime: jsxRuntime },
           ...oxcOptions,
         });
 
@@ -68,6 +79,7 @@ export default function vitePluginSvgr({
       const { transformWithEsbuild } = await import("vite");
       const res = await transformWithEsbuild(componentCode, id, {
         loader: "jsx",
+        ...(jsxRuntime === "automatic" ? { jsx: "automatic" } : {}),
         ...esbuildOptions,
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
-import { createFilter, type FilterPattern } from "@rollup/pluginutils";
 import type { Config } from "@svgr/core";
 import fs from "node:fs";
 import type {
   EsbuildTransformOptions,
   Plugin,
   transformWithOxc,
+  FilterPattern,
 } from "vite";
+import { createFilter } from "vite";
 
 type OxcTransformOptions = NonNullable<Parameters<typeof transformWithOxc>[2]>;
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -164,7 +164,7 @@ test("vitePluginSvgr exposes a pre plugin and only transforms matching ids", asy
     );
     assert.equal(transformed.map, null);
     assert.match(transformed.code, /export default/);
-    assert.match(transformed.code, /(React\.createElement|_jsx)\(/);
+    assert.match(transformed.code, /(React\.createElement|_jsx|jsx)\(/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -185,7 +185,10 @@ test("vitePluginSvgr respects a custom include pattern", async () => {
   const filePath = path.join(tempDir, "logo.svg");
 
   try {
-    await writeFile(filePath, '<svg viewBox="0 0 8 8"><path d="M0 0h8v8H0z" /></svg>');
+    await writeFile(
+      filePath,
+      '<svg viewBox="0 0 8 8"><path d="M0 0h8v8H0z" /></svg>',
+    );
 
     const plugin = vitePluginSvgr({
       include: "**/*.svg?component",
@@ -197,7 +200,7 @@ test("vitePluginSvgr respects a custom include pattern", async () => {
       await runLoad(plugin, `${filePath}?component`),
     );
     assert.match(transformed.code, /export default/);
-    assert.match(transformed.code, /(React\.createElement|_jsx)\(/);
+    assert.match(transformed.code, /(React\.createElement|_jsx|jsx)\(/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
@@ -226,6 +229,27 @@ test("vitePluginSvgr passes SVGR and esbuild options through the esbuild transfo
     assert.match(transformed.code, /h\(/);
     assert.match(transformed.code, /width: "1em"/);
     assert.match(transformed.code, /height: "1em"/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("vitePluginSvgr jsxRuntime classic uses React.createElement via esbuild", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "vite-plugin-svgr-"));
+  const filePath = path.join(tempDir, "logo.svg");
+
+  try {
+    await writeFile(
+      filePath,
+      '<svg viewBox="0 0 8 8"><path d="M0 0h8v8H0z" /></svg>',
+    );
+
+    const plugin = vitePluginSvgr({ jsxRuntime: "classic" });
+    const transformed = await plugin.load?.(`${filePath}?react`);
+
+    assert.equal(typeof transformed, "object");
+    assert.ok(transformed);
+    assert.match(transformed.code, /React\.createElement\(/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/test/process.test.ts
+++ b/test/process.test.ts
@@ -9,7 +9,10 @@ import vitePluginSvgr from "../src/index.ts";
 
 const fixtureRoot = fileURLToPath(new URL("./fixtures/basic", import.meta.url));
 const reactStubPath = path.join(fixtureRoot, "react-stub.js");
-const reactJsxRuntimeStubPath = path.join(fixtureRoot, "react-jsx-runtime-stub.js");
+const reactJsxRuntimeStubPath = path.join(
+  fixtureRoot,
+  "react-jsx-runtime-stub.js",
+);
 
 async function withServer(
   pluginOptions: Parameters<typeof vitePluginSvgr>[0],
@@ -45,7 +48,7 @@ test("vite transforms an svg request into a React component module", async () =>
     assert.match(importer.code, /react/);
 
     assert.ok(transformedSvg);
-    assert.match(transformedSvg.code, /(import \* as React from|react\/jsx-runtime)/);
+    assert.match(transformedSvg.code, /(import \* as React from|jsx-runtime)/);
     assert.match(transformedSvg.code, /(React\.createElement|_jsx)\(/);
     assert.match(transformedSvg.code, /viewBox: "0 0 10 10"/);
     assert.match(transformedSvg.code, /export default/);
@@ -57,7 +60,7 @@ test("vite respects a custom include query in the full transform flow", async ()
     const transformedSvg = await server.transformRequest("/logo.svg?component");
 
     assert.ok(transformedSvg);
-    assert.match(transformedSvg.code, /(import \* as React from|react\/jsx-runtime)/);
+    assert.match(transformedSvg.code, /(import \* as React from|jsx-runtime)/);
     assert.match(transformedSvg.code, /(React\.createElement|_jsx)\(/);
     assert.match(transformedSvg.code, /export default/);
   });


### PR DESCRIPTION
Adds a jsxRuntime option ("classic" | "automatic") to VitePluginSvgrOptions. When set, it is forwarded to @svgr/core's transform config and consistently applied to the esbuild transform (jsx: "automatic") and the Oxc/rolldown transform (jsx.runtime), ensuring the chosen runtime is honored across all pipelines.
Removes the @rollup/pluginutils dependency, replacing its usage with createFilter and FilterPattern imported directly from vite.

This feature will replace the following config

```ts
svgr({
  include: '**/*.svg',
  svgrOptions: { jsxRuntime: 'classic' },
  oxcOptions: {
    jsx: { runtime: 'classic' },
  },
}),
```

With

```ts
svgr({
  include: '**/*.svg',
  jsxRuntime: 'classic'
}),
```