### PR TITLE
Export plugin options interface (#146)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type {
 
 type OxcTransformOptions = NonNullable<Parameters<typeof transformWithOxc>[2]>;
 
-interface VitePluginSvgrOptions {
+export interface VitePluginSvgrOptions {
   svgrOptions?: Config;
   esbuildOptions?: EsbuildTransformOptions;
   oxcOptions?: OxcTransformOptions;


### PR DESCRIPTION
fixes #146: export of interface `VitePluginSvgrOptions` got lost