### PR TITLE
chore(codemods): declare MIT license in codemods package.json

### DIFF
--- a/codemods/package.json
+++ b/codemods/package.json
@@ -1,6 +1,7 @@
 {
   "name": "codemods",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "commonjs",
   "exports": {
     "./package.json": "./package.json"


### PR DESCRIPTION
Summary  
This PR adds explicit license metadata for the codemods subpackage by setting "license": "MIT" in codemods/package.json.

Context  
Some license scanners detect codemods as a standalone npm component (codemods:0.0.0) and report License Unknown, even though the repository is MIT licensed.

Changes  
- Add "license": "MIT" to package.json

Impact  
- Metadata-only change  
- No runtime or build behavior changes

Fixes #140