### PR TITLE
feat: add rolldownFilter option for native load hook filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ svgr({
 
   //  A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should ignore. By default no files are ignored.
   exclude: "",
+
+  // Optional: Rolldown-native id filter for the `load` hook. When set,
+  // Rolldown rejects non-matching ids in Rust before invoking the hook,
+  // avoiding JS↔Rust FFI overhead per module load. Has no effect under
+  // non-Rolldown bundlers (the legacy include/exclude filter still applies).
+  // See https://rolldown.rs/in-depth/why-plugin-hook-filter
+  rolldownFilter: { id: /\.svg\?react(?:[?#&]|$)/ },
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,34 @@ import type {
 
 type OxcTransformOptions = NonNullable<Parameters<typeof transformWithOxc>[2]>;
 
+/**
+ * Rolldown-native id filter shape. When set on the plugin, Rolldown evaluates
+ * the filter in Rust before crossing into JS, eliminating per-module FFI
+ * overhead in the `load` hook for non-matching ids.
+ *
+ * https://rolldown.rs/in-depth/why-plugin-hook-filter
+ */
+type RolldownIdFilter = {
+  id?: RegExp | { include?: RegExp | RegExp[]; exclude?: RegExp | RegExp[] };
+};
+
 interface VitePluginSvgrOptions {
   svgrOptions?: Config;
   esbuildOptions?: EsbuildTransformOptions;
   oxcOptions?: OxcTransformOptions;
   exclude?: FilterPattern;
   include?: FilterPattern;
+  /**
+   * Opt-in Rolldown-native id filter applied to the `load` hook. When set,
+   * Rolldown rejects non-matching ids in Rust before invoking the hook,
+   * avoiding the JS↔Rust FFI crossing for every module load. Has no effect
+   * under non-Rolldown bundlers (the legacy JS-side `include`/`exclude`
+   * filter still applies).
+   *
+   * @example
+   * vitePluginSvgr({ rolldownFilter: { id: /\.svg\?react(?:[?#&]|$)/ } })
+   */
+  rolldownFilter?: RolldownIdFilter;
 }
 
 export default function vitePluginSvgr({
@@ -23,14 +45,13 @@ export default function vitePluginSvgr({
   oxcOptions,
   include = "**/*.svg?react",
   exclude,
+  rolldownFilter,
 }: VitePluginSvgrOptions = {}): Plugin {
   const filter = createFilter(include, exclude);
   const postfixRE = /[?#].*$/s;
 
-  return {
-    name: "vite-plugin-svgr",
-    enforce: "pre", // to override `vite:asset`'s behavior
-    async load(id) {
+  const handler: Extract<NonNullable<Plugin["load"]>, (...args: any[]) => any> =
+    async function (id) {
       if (!filter(id)) {
         return;
       }
@@ -48,7 +69,8 @@ export default function vitePluginSvgr({
           defaultPlugins: [jsx],
         },
       });
-      const meta = (this as { meta?: { rolldownVersion?: string } } | undefined)?.meta;
+      const meta = (this as { meta?: { rolldownVersion?: string } } | undefined)
+        ?.meta;
 
       if (meta?.rolldownVersion != null) {
         /* c8 ignore next */
@@ -75,6 +97,13 @@ export default function vitePluginSvgr({
         code: res.code,
         map: null, // TODO:
       };
-    },
+    };
+
+  return {
+    name: "vite-plugin-svgr",
+    enforce: "pre", // to override `vite:asset`'s behavior
+    load: rolldownFilter
+      ? ({ filter: rolldownFilter, handler } as Plugin["load"])
+      : handler,
   };
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -264,6 +264,40 @@ test("vitePluginSvgr passes Oxc options through the rolldown transform", async (
   }
 });
 
+test("vitePluginSvgr exposes the rolldown filter shape when rolldownFilter is set", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "vite-plugin-svgr-"));
+  const filePath = path.join(tempDir, "logo.svg");
+
+  try {
+    await writeFile(
+      filePath,
+      '<svg viewBox="0 0 4 4"><path d="M0 0h4v4H0z" /></svg>',
+    );
+
+    const idFilter = /\.svg\?react(?:[?#&]|$)/;
+    const plugin = vitePluginSvgr({
+      rolldownFilter: { id: idFilter },
+    });
+
+    assert.ok(plugin.load && typeof plugin.load === "object");
+    assert.deepEqual(plugin.load.filter, { id: idFilter });
+
+    const transformed = expectTransformResult(
+      await runLoad(plugin, `${filePath}?react`),
+    );
+    assert.match(transformed.code, /export default/);
+    assert.match(transformed.code, /(React\.createElement|_jsx)\(/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("vitePluginSvgr exposes the legacy load function when rolldownFilter is not set", () => {
+  const plugin = vitePluginSvgr();
+
+  assert.equal(typeof plugin.load, "function");
+});
+
 test("CommonJS require returns the plugin function", async () => {
   ensurePackageBuilt();
 


### PR DESCRIPTION
## Summary

Adds an opt-in `rolldownFilter` option that lets the `load` hook use Rolldown's native `{ filter, handler }` shape so non-matching ids are rejected in Rust before crossing into JS.

## Motivation

When running under `rolldown-vite`, the current `load` hook is a plain async function with `enforce: 'pre'`, so it's invoked for **every** module load. Each call crosses the JS↔Rust FFI boundary, runs `createFilter(id)` in JS, then returns `undefined` for the ~99% of files that don't end in `?react`.

Rolldown documents this in [Why Plugin Hook Filters](https://rolldown.rs/in-depth/why-plugin-hook-filter) — their benchmarks show 10 plugins without filters making builds 3.74× slower because the Rust core has to halt parallel processing, cross into JS, run all plugins sequentially, and return — even for files the plugins ignore. With filters applied at the Rust level, the overhead disappears.

In a real codebase test (Amplitude monorepo, ~22 `?react` imports across 10k+ modules), `vite-plugin-svgr` consistently dominated `PLUGIN_TIMINGS` (53–63% of plugin time per app, e.g. onenav 63%, agents 53%, voc 40%) despite doing almost no work. After enabling `rolldownFilter`, `vite-plugin-svgr` drops out of the top 5 entirely.

## Design

Non-breaking, additive option:

- **Unset**: behavior unchanged — `plugin.load` stays a plain async function, the legacy include/exclude filter is the only gate.
- **Set**: `plugin.load` uses the native `{ filter, handler }` shape. The inner `createFilter` still runs, so custom `include`/`exclude` patterns continue to apply on top of the rolldown filter.

```js
svgr({
  rolldownFilter: { id: /\.svg\?react(?:[?#&]|$)/ },
});
```

`rolldownFilter` accepts the same shape Rolldown's native filter expects (`{ id: RegExp | { include, exclude } }`).

## Test plan

- [x] New test: `vitePluginSvgr exposes the rolldown filter shape when rolldownFilter is set` — verifies `plugin.load` is `{ filter, handler }` and that the handler still produces a transformed React component
- [x] New test: `vitePluginSvgr exposes the legacy load function when rolldownFilter is not set` — verifies non-breaking default
- [x] Existing 7 tests still pass (the 1 pre-existing failure is unrelated — `node:module`'s `registerHooks` requires Node 22.15+ on the test host)
- [x] Validated end-to-end against a real rolldown-vite build (`PLUGIN_TIMINGS` shows `vite-plugin-svgr` removed from top 5 with the option set)

## Notes

- No effect on non-rolldown bundlers — Vite's plugin pipeline accepts both shapes, so the option is safe under esbuild-vite and rollup as well, but the FFI savings only materialize under rolldown-vite.
- Could be made the default in a future major if desired; left opt-in here to preserve current behavior for existing consumers.