### PR TITLE
fix: declare react as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,13 @@
     "vite8": "npm:vite@8.0.3"
   },
   "peerDependencies": {
+    "react": "*",
     "vite": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@svgr/plugin-jsx':
         specifier: ^8.1.0
         version: 8.1.0(@svgr/core@8.1.0(typescript@6.0.2))
+      react:
+        specifier: '*'
+        version: 19.2.8
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -1732,6 +1735,10 @@ packages:
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3452,6 +3459,8 @@ snapshots:
       source-map-js: 1.2.1
 
   quansync@1.0.0: {}
+
+  react@19.2.8: {}
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
`client.d.ts` declares the `*.svg?react` module with `import * as React from "react"`, so React types are part of the package's public type surface. But `react` is not declared as a dependency anywhere in `package.json`.

With strict package managers (pnpm with isolated `node_modules`, Yarn PnP) `react` is not resolvable from inside `vite-plugin-svgr`, the ambient declaration fails, and consumers silently lose typings for:

```ts
import Logo from "./logo.svg?react";
```

Declaring react: "*" as a peer dependency fixes resolution. It's marked optional so Preact-only setups (#56) keep installing without a peer warning.